### PR TITLE
update 3a500 uefi

### DIFF
--- a/content/zh-cn/posts/3a5000-uefi.md
+++ b/content/zh-cn/posts/3a5000-uefi.md
@@ -6,9 +6,11 @@ author = "武校田"
 draft = false
 comment = true
 toc = true
+featured = true
 reward = false
 categories = [
-  ""
+  "固件",
+  "UEFI"
 ]
 tags = [
   "新闻"
@@ -49,7 +51,11 @@ GPT: GUID（Globals Unique Identifiers）Partition Table 全局唯一标识，�
 
 UEFI规范里，在GPT分区表的基础上，规定了一个EFI系统分区（EFI System Partition，ESP），ESP要格式化成FAT32，EFI启动文件要放在 `<esp分区>/EFI` 目录下面。
 
-在龙芯固件中，默认的EFI文件加载路径是`<esp>/EFI/BOOT/BOOTLOONGARCH.EFI`，当写入固件的启动项失败时，可以将efi文件放在这个路径，以让固件自动加载。
+在龙芯固件中，默认的EFI文件加载路径是 `<esp>/EFI/BOOT/BOOTLOONGARCH64.EFI`，当写入固件的启动项失败时，可以将 efi 文件放在这个路径，以让固件自动加载。
+
+**注：**
+
+未提交上游的旧固件版本，默认的EFI文件加载路径是 `<esp>/EFI/BOOT/BOOTLOONGARCH.EFI`。
 
 EFI 系统分区，通过挂载在 `/boot/efi` 目录中：
 


### PR DESCRIPTION
把这篇文章更新一下：
1. 上游最新固件，默认的EFI文件加载路径是 `<esp>/EFI/BOOT/BOOTLOONGARCH64.EFI`
2. 加到右边“精选文章”中。