### PR TITLE
update view.sh to improve multiple os support:

### DIFF
--- a/view.sh
+++ b/view.sh
@@ -1,10 +1,13 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
+
+verlte() {
+    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
 
 ver=`hugo version|awk '{print $2}'`
 version=${ver#v*}
-result=`vercmp $version 0.7`
 
-if [ $result -gt 0 ]; then
+if verlte 0.7 $version ; then
   hugo --printI18nWarnings --disableFastRender --ignoreCache server
 else
   hugo --i18n-warnings --disableFastRender --ignoreCache server


### PR DESCRIPTION
1. use /usr/bin/env to locate bash instead of /usr/bin/bash
2. write a version compare function in shell syntax to avoid the
   dependence on vercmp program.